### PR TITLE
fix missing dependency notice for libloading library

### DIFF
--- a/NOTICE.md
+++ b/NOTICE.md
@@ -1,0 +1,20 @@
+NOTICES
+
+This repository incorporates material as listed below or described in the code.
+
+libloading
+
+[https://github.com/nagisa/rust_libloading](https://github.com/nagisa/rust_libloading)
+
+Copyright © 2015, Simonas Kazlauskas
+
+Permission to use, copy, modify, and/or distribute this software for any purpose with or without
+fee is hereby granted, provided that the above copyright notice and this permission notice appear
+in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS
+SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE
+AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT,
+NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
+THIS SOFTWARE.


### PR DESCRIPTION
The libloading library was included as a dependency but lacked proper
attribution in our dependency notices. This commit adds the required
notice to ensure compliance with the library's licensing terms.
The notice includes:

Library name
Copyright information
Link to the original repository

This ensures all third-party dependencies are properly acknowledged
in accordance with their respective licenses.