### PR TITLE
Fix defmt integration conflicts and add conditional compilation guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,10 @@ To get started with adding SystemView tracing to your Embassy application:
   systemview_tracing::init_tracing(system_clock_frequency)
   ```
   Note: You can find system_clock_frequency by SYS_CLK_FREQ = CORE_CPU_FREQ / 2
+
+  4. Since the `defmt_rtt` crate cannot be used with this crate simultaneously, make sure to add this config flag before any `defmt_rtt` import:
+
+  ```
+  #[cfg(not(feature = "systemview-tracing"))]
+  use defmt_rtt as _;
+  ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -113,11 +113,6 @@ mod tracing_impl {
 
     #[no_mangle]
     pub extern "C" fn _defmt_release(_token: isize) {}
-
-    #[no_mangle]
-    pub extern "C" fn _defmt_timestamp() -> u64 {
-        0
-    }
 }
 
 #[cfg(not(feature = "tracing-enabled"))]


### PR DESCRIPTION
This PR resolves linker errors that occur when using defmt alongside systemview-tracing by removing a duplicate `defmt_timestamp` symbol definition and adds documentation guidance for conditionally compiling out `defmt_rtt` imports to prevent feature conflicts. The changes ensure users can properly integrate SystemView tracing into Embassy applications without encountering "symbol multiply defined" errors during the build process.